### PR TITLE
feat(akamai): implement cloudlets v3 (refs #13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 .vscode
 *.code-workspace
+.bossmancache

--- a/bossman/config.py
+++ b/bossman/config.py
@@ -21,6 +21,15 @@ _DEFAULT_RESOURCE_TYPES = (
       "switch_key": getenv("AKAMAI_EDGERC_SWITCHKEY", None),
     }
   },
+  {
+    "module": "bossman.plugins.akamai.cloudlet_v3",
+    "pattern": "akamai/cloudlet/{name}",
+    "options": {
+      "edgerc": getenv("AKAMAI_EDGERC", expanduser("~/.edgerc")),
+      "section": getenv("AKAMAI_EDGERC_SECTION", "default"),
+      "switch_key": getenv("AKAMAI_EDGERC_SWITCHKEY", None),
+    }
+  },
 )
 
 class PathPatternMatch:

--- a/bossman/plugins/akamai/cloudlet_v3/__init__.py
+++ b/bossman/plugins/akamai/cloudlet_v3/__init__.py
@@ -1,0 +1,3 @@
+from .client import *
+from .data import *
+from .resourcetype import *

--- a/bossman/plugins/akamai/cloudlet_v3/client.py
+++ b/bossman/plugins/akamai/cloudlet_v3/client.py
@@ -1,0 +1,111 @@
+from datetime import datetime
+import dateutil.parser
+from typing import List
+from cattr import Converter
+
+from bossman.logging import get_class_logger
+from bossman.plugins.akamai.lib.edgegrid import Session
+from .data import *
+from .error import *
+
+class CloudletAPIV3Client:
+  def __init__(self, edgerc, section, switch_key=None, **kwargs):
+    self.logger = get_class_logger(self)
+    self.session = Session(edgerc, section, switch_key=switch_key, **kwargs)
+    self.converter = Converter()
+    self.converter.register_structure_hook(datetime, lambda d, t: dateutil.parser.isoparse(d))
+
+  def get_policy_by_name(self, name):
+    self.logger.debug("get_policy_by_name name={name}".format(name=name))
+    id = None
+    policies = self.get_policies()
+    for policy in policies:
+      if policy.name == name:
+        return policy
+    raise PolicyNameNotFound(name)
+
+  def get_policies(self) -> List[SharedPolicy]:
+    self.logger.debug("get_policies")
+    response = self.session.get("/cloudlets/v3/policies")
+    if response.status_code != 200:
+      raise CloudletAPIV3Error(response.json())
+    # import json
+    # print(json.dumps(response.json(), indent=2))
+    response = self.converter.structure(response.json(), GetPoliciesResponse)
+    return response.content
+
+  def get_policy_version(self, policyId: int, policyVersion: int) -> SharedPolicyVersion:
+    self.logger.debug("get_policy_version policyId={policyId}, policyVersion={policyVersion}".format(policyId=policyId, policyVersion=policyVersion))
+    response = self.session.get("/cloudlets/v3/policies/{policyId}/versions/{policyVersion}".format(policyId=policyId, policyVersion=policyVersion))
+    if response.status_code != 200:
+      raise CloudletAPIV3Error(response.json())
+    return self.converter.structure(response.json(), SharedPolicyVersion)
+
+  def get_latest_policy_version(self, policyId: int) -> Optional[SharedPolicyVersion]:
+    self.logger.debug("get_policy_version policyId={policyId}".format(policyId=policyId))
+    response = self.session.get("/cloudlets/v3/policies/{policyId}/versions".format(policyId=policyId), params=dict(size=10))
+    if response.status_code != 200:
+      raise CloudletAPIV3Error(response.json())
+    policy_versions = self.converter.structure(response.json(), GetPolicyVersionsResponse)
+    if len(policy_versions.content):
+      return policy_versions.content[0]
+    return None
+
+  def get_latest_policy_versions(self, policyId: int, count: int) -> List[SharedPolicyVersion]:
+    self.logger.debug("get_latest_policy_versions policyId={policyId}, count={count}".format(policyId=policyId, count=count))
+    response = self.session.get("/cloudlets/v3/policies/{policyId}/versions".format(policyId=policyId), params=dict(size=count))
+    if response.status_code != 200:
+      raise CloudletAPIV3Error(response.json())
+    policy_versions = self.converter.structure(response.json(), GetPolicyVersionsResponse)
+    return policy_versions.content
+
+  def create_policy(self, policyName: str, description: str, cloudletType: SharedPolicyCloudletType, groupId: int) -> SharedPolicy:
+    self.logger.debug("create_policy policyName={policyName}".format(policyName=policyName))
+    response = self.session.post("/cloudlets/v3/policies", json=dict(
+      name=policyName,
+      cloudletType=cloudletType.value,
+      groupId=groupId,
+      description=description,
+    ))
+    if response.status_code != 201:
+      raise CloudletAPIV3Error(response.json())
+    return self.converter.structure(response.json(), SharedPolicy)
+
+  def update_policy(self, policyId: int, description: str, groupId: int) -> SharedPolicy:
+    self.logger.debug("update_policy policyName={policyId}".format(policyId=policyId))
+    response = self.session.put("/cloudlets/v3/policies/{policyId}".format(policyId=policyId), json=dict(
+      groupId=groupId,
+      description=description,
+    ))
+    if response.status_code != 202:
+      raise CloudletAPIV3Error(response.json())
+    return self.converter.structure(response.json(), SharedPolicy)
+
+  def create_policy_version(self, policyId: int, description: str, matchRules: List[dict]) -> SharedPolicyVersion:
+    self.logger.debug("create_policy_version policyId={policyId}".format(policyId=policyId))
+    response = self.session.post("/cloudlets/v3/policies/{policyId}/versions".format(policyId=policyId), json=dict(
+      description=description,
+      matchRules=matchRules,
+    ))
+    if response.status_code != 201:
+      raise CloudletAPIV3Error(response.json())
+    return self.converter.structure(response.json(), SharedPolicyVersion)
+
+  def activate_policy_version(self, policyId: int, policyVersion: int, network: Network) -> SharedPolicyActivation:
+    self.logger.debug("activate_policy_version policyId={policyId}, policyVersion={policyVersion}".format(policyId=policyId, policyVersion=policyVersion))
+    response = self.session.post("/cloudlets/v3/policies/{policyId}/activations".format(policyId=policyId), json=dict(
+      network=network.value,
+      operation=SharedPolicyActivationOperation.ACTIVATION.value,
+      policyVersion=policyVersion,
+    ))
+    if response.status_code != 202:
+      result = response.json().get('errors')[0]
+      raise CloudletAPIV3Error(result.get('detail'))
+    return self.converter.structure(response.json(), SharedPolicyActivation)
+
+  def get_policy_version_activation_status(self, activation: SharedPolicyActivation) -> SharedPolicyActivation:
+    self.logger.debug("get_policy_version_activation_status policyId={policyId}, activationId={activationId}".format(policyId=activation.policyId, activationId=activation.id))
+    response = self.session.get("/cloudlets/v3/policies/{policyId}/activations/{activationId}".format(policyId=activation.policyId, activationId=activation.id))
+    if response.status_code != 200:
+      raise CloudletAPIV3Error(response.json())
+    return self.converter.structure(response.json(), SharedPolicyActivation)

--- a/bossman/plugins/akamai/cloudlet_v3/data.py
+++ b/bossman/plugins/akamai/cloudlet_v3/data.py
@@ -1,0 +1,102 @@
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+
+
+class Network(Enum):
+  PRODUCTION = 'PRODUCTION'
+  STAGING = 'STAGING'
+  
+  @property
+  def alias(self) -> str:
+    return re.sub("[aeiou]", "", self.value, flags=re.IGNORECASE)[:3].upper()
+  
+  @property
+  def color(self) -> str:
+    return "green" if self == Network.PRODUCTION else "magenta"
+
+class SharedPolicyActivationOperation(Enum):
+  ACTIVATION = 'ACTIVATION'
+  DEACTIVATION = 'DEACTIVATION'
+
+class SharedPolicyActivationStatus(Enum):
+  IN_PROGRESS = 'IN_PROGRESS'
+  SUCCESS = 'SUCCESS'
+  FAILED = 'FAILED'
+
+class SharedPolicyPolicyType(Enum):
+  SHARED = 'SHARED'
+
+class SharedPolicyCloudletType(Enum):
+  ER = 'ER'
+  FR = 'FR'
+  AS = 'AS'
+
+@dataclass
+class SharedPolicyActivation:
+  id: int
+  createdBy: str
+  createdDate: datetime
+  finishDate: Optional[datetime]
+  network: Network
+  operation: SharedPolicyActivationOperation
+  status: SharedPolicyActivationStatus
+  policyId: int
+  policyVersion: int
+  policyVersionDeleted: bool
+
+@dataclass
+class SharedPolicyCurrentActivationsNetwork:
+  effective: Optional[SharedPolicyActivation] = None
+  latest: Optional[SharedPolicyActivation] = None
+
+@dataclass
+class SharedPolicyCurrentActivations:
+  production: SharedPolicyCurrentActivationsNetwork = None
+  staging: SharedPolicyCurrentActivationsNetwork = None
+
+@dataclass
+class SharedPolicy:
+  id: int
+  name: str
+  description: str
+  policyType: SharedPolicyPolicyType
+  cloudletType: SharedPolicyCloudletType
+  createdBy: str
+  createdDate: datetime
+  currentActivations: SharedPolicyCurrentActivations
+  groupId: int
+  modifiedBy: str
+  modifiedDate: datetime
+
+@dataclass
+class GetPoliciesResponse:
+  content: List[SharedPolicy]
+
+@dataclass
+class SharedPolicyVersion:
+  policyId: int
+  version: int
+  createdBy: str
+  createdDate: datetime
+  modifiedBy: str
+  modifiedDate: datetime
+  description: str
+  matchRules: Optional[List[dict]] = None
+
+@dataclass
+class GetPolicyVersionsResponse:
+  content: List[SharedPolicyVersion]
+
+@dataclass
+class SharedPolicyAsCode:
+  """
+  Subset of SharedPolicy that must be versioned in order to support CRUD.
+  """
+  description: str
+  groupId: int
+  cloudletType: SharedPolicyCloudletType
+  matchRules: Optional[List[dict]] = None

--- a/bossman/plugins/akamai/cloudlet_v3/error.py
+++ b/bossman/plugins/akamai/cloudlet_v3/error.py
@@ -1,0 +1,10 @@
+from bossman.errors import BossmanError
+
+class CloudletAPIV3Error(BossmanError):
+  pass
+
+class PolicyNameNotFound(CloudletAPIV3Error):
+  pass
+
+class PolicyVersionValidationError(CloudletAPIV3Error):
+  pass

--- a/bossman/plugins/akamai/cloudlet_v3/resource.py
+++ b/bossman/plugins/akamai/cloudlet_v3/resource.py
@@ -1,0 +1,24 @@
+import pathlib
+from bossman.abc import ResourceABC
+
+class SharedPolicyResource(ResourceABC):
+  def __init__(self, path, **kwargs):
+    super(SharedPolicyResource, self).__init__(path)
+    self.__name = kwargs.get("name")
+
+  @property
+  def name(self):
+    return self.__name
+
+  @property
+  def policy_path(self):
+    # All operations use unix-style paths; this is important
+    return str(pathlib.PurePosixPath(self.path) / "policy.json")
+
+  @property
+  def paths(self):
+    return (self.policy_path,)
+
+  def __rich__(self):
+    prefix = self.path.replace(self.name, "")
+    return "[grey53]{}[/][yellow]{}[/]".format(prefix, self.name)

--- a/bossman/plugins/akamai/cloudlet_v3/resourcetype.py
+++ b/bossman/plugins/akamai/cloudlet_v3/resourcetype.py
@@ -1,0 +1,202 @@
+from collections import defaultdict
+import json
+import random
+import re
+from os.path import expanduser
+import time
+from types import SimpleNamespace
+from typing import List
+from bossman.cache import cache
+from bossman.errors import BossmanError, BossmanValidationError
+from bossman.abc import ResourceTypeABC
+from bossman.abc import ResourceABC
+from bossman.abc import ResourceApplyResultABC
+from bossman.config import ResourceTypeConfig
+from bossman.plugins.akamai.cloudlet_v3 import CloudletAPIV3Client, CloudletAPIV3Error
+from bossman.plugins.akamai.cloudlet_v3.data import Network, SharedPolicyActivationStatus, SharedPolicyAsCode, SharedPolicyVersion
+from bossman.plugins.akamai.cloudlet_v3.error import PolicyNameNotFound, PolicyVersionValidationError
+from bossman.plugins.akamai.cloudlet_v3.resource import SharedPolicyResource
+from bossman.plugins.akamai.cloudlet_v3.schema import validate_policy_version
+from bossman.plugins.akamai.cloudlet_v3.ui import SharedPolicyApplyResult, SharedPolicyStatus, SharedPolicyVersionStatus
+from bossman.plugins.akamai.lib.edgegrid import EdgegridError
+from bossman.plugins.akamai.utils import GenericVersionComments
+from bossman.repo import Repo, Revision, RevisionDetails
+
+RE_COMMIT = re.compile("^commit: ([a-z0-9]*)", re.MULTILINE)
+
+
+class CloudletError(BossmanError):
+  pass
+
+class ResourceTypeOptions:
+  def __init__(self, options):
+    from os import environ
+    self.env_prefix = options.get("env_prefix", "")
+    self.edgerc = expanduser(environ.get("%sEDGERC" % self.env_prefix, options.get("edgerc", "~/.edgerc")))
+    self.section = environ.get("%sEDGERC_SECTION" % self.env_prefix, options.get("section", "papi"))
+    self.switch_key = environ.get("%sEDGERC_SWITCH_KEY" % self.env_prefix, options.get("switch_key", None))
+
+class ResourceType(ResourceTypeABC):
+  def __init__(self, repo: Repo, config: ResourceTypeConfig):
+    super(ResourceType, self).__init__(repo, config)
+    self.options = ResourceTypeOptions(config.options)
+    self.client = CloudletAPIV3Client(self.options.edgerc, self.options.section, self.options.switch_key)
+
+  def create_resource(self, path: str, **kwargs):
+    return SharedPolicyResource(path, **kwargs)
+
+  def get_resource_status(self, resource: SharedPolicyResource):
+    try:
+      policy = self.client.get_policy_by_name(resource.name)
+
+      production_activations = dict()
+      staging_activations = dict()
+      interesting_versions = set()
+
+      if policy is not None:
+        if policy.currentActivations.production.latest != None:
+          interesting_versions.add(policy.currentActivations.production.latest.policyVersion)
+          production_activations[policy.currentActivations.production.latest.policyVersion] = policy.currentActivations.production.latest
+        if policy.currentActivations.production.effective != None:        
+          interesting_versions.add(policy.currentActivations.production.effective.policyVersion)
+          production_activations[policy.currentActivations.production.effective.policyVersion] = policy.currentActivations.production.effective
+        if policy.currentActivations.staging.latest != None:
+          interesting_versions.add(policy.currentActivations.staging.latest.policyVersion)
+          staging_activations[policy.currentActivations.staging.latest.policyVersion] = policy.currentActivations.staging.latest
+        if policy.currentActivations.staging.effective != None:        
+          interesting_versions.add(policy.currentActivations.staging.effective.policyVersion)
+          staging_activations[policy.currentActivations.staging.effective.policyVersion] = policy.currentActivations.staging.effective
+        latest_version = self.client.get_latest_policy_version(policy.id)
+        latest_versions = []
+        if len(interesting_versions):
+          window = max(latest_version.version - min(interesting_versions) + 1, 10)
+          latest_versions = self.client.get_latest_policy_versions(policy.id, window)
+        elif latest_version != None:
+          latest_versions = [latest_version]
+        if latest_version != None:
+          interesting_versions.add(latest_version.version)
+      return SharedPolicyStatus(self.repo, resource, [
+          SharedPolicyVersionStatus(
+            self.repo,
+            resource,
+            v,
+            production_activations.get(v.version, None),
+            staging_activations.get(v.version, None)
+          )
+          for v in latest_versions
+          if v.version in interesting_versions
+        ],
+        exists=True
+      )
+    except CloudletAPIV3Error as e:
+      return SharedPolicyStatus(self.repo, resource, [], exists=False, error=e)
+
+  def is_pending(self, resource: SharedPolicyResource, revision: Revision):
+    notes = revision.get_notes(resource.path)
+    if notes.get("has_errors", False):
+      return False
+    return not self.is_applied(resource, revision)
+
+  def is_applied(self, resource: SharedPolicyResource, revision: Revision):
+    notes = revision.get_notes(resource.path)
+    policy_version = notes.get("policy_version", None)
+    return policy_version is not None
+
+  def get_revision_details(self, resource: SharedPolicyResource, revision: Revision) -> RevisionDetails:
+    notes = revision.get_notes(resource.path)
+    policy_version = notes.get("policy_version", None)
+    return RevisionDetails(id=revision.id, details="v"+str(policy_version) if policy_version else None)
+
+  def apply_change(self, resource: SharedPolicyResource, revision: Revision, previous_revision: Revision) -> ResourceApplyResultABC:
+    # we should only call this function if the Revision concerns the resource
+    assert len(set(resource.paths).intersection(revision.affected_paths)) > 0
+
+    notes = SimpleNamespace(
+      policy_id=None,
+      policy_version=None,
+      has_errors=False
+    )
+
+    try:
+
+      try:
+        # Get the policy json from the commit
+        policy_data = revision.show_path(resource.policy_path, textconv=True)
+        if policy_data is None:
+          raise PolicyVersionValidationError("missing policy version JSON")
+        policy_data: SharedPolicyAsCode = self.client.converter.structure(json.loads(policy_data), SharedPolicyAsCode)
+        # before changing anything in API, check that the json files are valid
+        validate_policy_version(policy_data)
+      except PolicyVersionValidationError as e:
+        notes.has_errors = True
+        raise e
+
+      try:
+        # If the policy exists, retrieve it
+        policy = self.client.get_policy_by_name(resource.name)
+      except PolicyNameNotFound:
+        # Otherwise, create it
+        policy = self.client.create_policy(resource.name, policy_data.description, policy_data.cloudletType, policy_data.groupId)
+
+      policy_version = self.client.create_policy_version(
+        policy.id,
+        str(GenericVersionComments.from_revision(revision)),
+        policy_data.matchRules
+      )
+
+      notes.policy_id = policy.id
+      notes.policy_version = policy_version.version
+
+      return SharedPolicyApplyResult(resource, revision, policy_version)
+    except RuntimeError as e:
+        return SharedPolicyApplyResult(resource, revision, error=e)
+    finally:
+      # Finally, assign the updated values to the git notes
+      revision.get_notes(resource.path).set(**vars(notes))
+
+  def validate_working_tree(self, resource: SharedPolicyResource):
+    try:
+      with open(resource.policy_path, "r") as fd:
+        policy_data = fd.read()
+        policy_data: SharedPolicyAsCode = self.client.converter.structure(json.loads(policy_data), SharedPolicyAsCode)
+        validate_policy_version(policy_data)
+    except (NotADirectoryError, FileNotFoundError) as e:
+      raise PolicyVersionValidationError("file not found {}".format(e.filename))
+
+  def _release(self, network: Network, resource: SharedPolicyResource, revision: Revision, on_update: callable = lambda resource, status, progress: None):
+    notes = revision.get_notes(resource.path)
+    policy_id = notes.get("policy_id")
+    if not policy_id:
+      policy_id = self.client.get_policy_by_name(resource.name).id
+    policy_version = notes.get("policy_version")
+    if not policy_id:
+      on_update(resource, "[magenta]Policy does not exist[/]", None)
+      return
+    if not policy_version:
+      on_update(resource, "[magenta]Revision not deployed[/]", 1)
+      return
+    if notes.get("has_errors") == True:
+      on_update(resource, ":boom: [grey53]v{:<3}[/] Policy version has validation errors".format(policy_version), 1)
+      return
+
+    describe = lambda activation_status: "[{}]{}[/] [grey53]v{:<3}[/] [bright_white]{}[/]".format(network.color, network.alias, policy_version, activation_status)
+
+    try:
+      on_update(resource, describe("STARTING"), None)
+      activation = self.client.activate_policy_version(policy_id, policy_version, network)
+      on_update(resource, describe(activation.status.value), 0.5)
+      while activation.status == SharedPolicyActivationStatus.IN_PROGRESS:
+        time.sleep(random.randint(-10, 10) + 20)
+        activation = self.client.get_policy_version_activation_status(activation)
+        on_update(resource, describe(activation.status.value), 0.5)
+      on_update(resource, describe(activation.status.value), 1)
+    except CloudletAPIV3Error as e:
+      on_update(resource, ":boom: [grey53]v{policy_version:<3}[/] {error}".format(policy_version=policy_version, error=e), 1)
+    except RuntimeError as e:
+      on_update(resource, ":boom: [grey53]v{policy_version:<3}[/] An error occurred: {e}".format(policy_version=policy_version, e=e), 1)
+
+  def prerelease(self, resource: ResourceABC, revision: Revision, on_update: callable = lambda resource, status, progress: None):
+    return self._release(Network.STAGING, resource, revision, on_update)
+
+  def release(self, resource: ResourceABC, revision: Revision, on_update: callable = lambda resource, status, progress: None):
+    return self._release(Network.PRODUCTION, resource, revision, on_update)

--- a/bossman/plugins/akamai/cloudlet_v3/schema.py
+++ b/bossman/plugins/akamai/cloudlet_v3/schema.py
@@ -1,0 +1,31 @@
+import jsonschema, jsonschema.validators, json
+import pkg_resources
+
+from bossman.plugins.akamai.cloudlet_v3.data import SharedPolicyAsCode
+
+from .error import *
+
+_PACKAGE = __name__.rsplit('.', 1)[0]
+
+def get_schema(name):
+  path = pkg_resources.resource_filename(_PACKAGE, 'schemas/' + name)
+  with open(path) as fd:
+    return json.loads(fd.read())
+
+def validate_policy_version(data: SharedPolicyAsCode):
+  try:
+    schema = get_schema('update-policy-version.json')
+    validator = jsonschema.validators.Draft4Validator(schema, resolver=jsonschema.validators.RefResolver(
+      pkg_resources.resource_filename(_PACKAGE, 'schemas/'),
+      pkg_resources.resource_filename(_PACKAGE, 'schemas/update-policy-version.json'),
+    ))
+    for f in ['match_rule-AS-1.0.json', 'match_rule-ER-1.0.json', 'match_rule-FR-1.0.json', 'match-rules.json']:
+      validator.resolver.store['file://' + f] = get_schema(f)
+    validator.validate(dict(description="dummy description", matchRules=data.matchRules))
+  except json.decoder.JSONDecodeError as err:
+    raise PolicyVersionValidationError("bad rules.json", err.args)
+  except jsonschema.ValidationError as err:
+    raise PolicyVersionValidationError("invalid rules.json", {
+      "message": err.message,
+      "path": '/' + '/'.join(str(i) for i in err.absolute_path)
+    })

--- a/bossman/plugins/akamai/cloudlet_v3/schemas/match-rules.json
+++ b/bossman/plugins/akamai/cloudlet_v3/schemas/match-rules.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "file://match-rule.json",
+  "type": "array",
+  "description": "A list of Cloudlet-specific match rules for this shared policy. Currently, you can create match rules only for the Edge Redirector, Forward Rewrite, and Audience Segmentation Cloudlets. ",
+  "oneOf": [
+    {
+      "type": "array",
+      "items": {
+        "$ref": "file://match_rule-ER-1.0.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "file://match_rule-AS-1.0.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "file://match_rule-FR-1.0.json"
+      }
+    }
+  ]
+}

--- a/bossman/plugins/akamai/cloudlet_v3/schemas/match_rule-AS-1.0.json
+++ b/bossman/plugins/akamai/cloudlet_v3/schemas/match_rule-AS-1.0.json
@@ -1,0 +1,170 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "AUDIENCE SEGMENTATION MATCH RULE",
+  "description" : "applied to create/update match rule requests for AS cloudlets, where requests are of the form: POST|PUT /api/v2/policies/{policyId}/versions/{versionId}/rules/{ruleId}",
+  "version" : "1.0",
+  "type" : "object",
+  "definitions" : {
+    "matchRuleType" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : [ "string", "null" ],
+          "maxLength" : 8192
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "asMatchRule" ]
+        },
+        "start" : {
+          "type" : "integer",
+          "minimum" : 0
+        },
+        "end" : {
+          "type" : "integer",
+          "minimum" : 0
+        },
+        "id" : {
+          "type" : [ "integer", "null" ]
+        },
+        "matches" : {
+          "type" : [ "array", "null" ],
+          "items" : {
+            "$ref" : "#/definitions/matchCriteriaType"
+          }
+        },
+        "disabled" : {
+          "type" : "boolean"
+        },
+        "akaRuleId" : {
+          "type" : "string"
+        },
+        "matchURL" : {
+          "type" : [ "string", "null" ],
+          "maxLength" : 8192
+        },
+        "forwardSettings" : {
+          "type" : "object",
+          "properties" : {
+            "pathAndQS" : {
+              "type" : "string",
+              "minLength" : 1,
+              "maxLength" : 8192
+            },
+            "useIncomingQueryString" : {
+              "type" : "boolean"
+            },
+            "originId" : {
+              "type" : [ "string", "null" ],
+              "maxLength" : 8192
+            }
+          },
+          "additionalProperties" : false
+        }
+      },
+      "additionalProperties" : false,
+      "required" : [ "type" ]
+    },
+    "matchCriteriaType" : {
+      "type" : "object",
+      "properties" : {
+        "caseSensitive" : {
+          "type" : "boolean"
+        },
+        "matchValue" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "negate" : {
+          "type" : "boolean"
+        },
+        "matchOperator" : {
+          "type" : "string",
+          "enum" : [ "contains", "exists", "equals" ]
+        },
+        "matchType" : {
+          "type" : "string",
+          "enum" : [ "header", "hostname", "path", "extension", "query", "range", "regex", "cookie", "deviceCharacteristics", "clientip", "continent", "countrycode", "regioncode", "protocol", "method", "proxy" ]
+        },
+        "checkIPs" : {
+          "type" : "string",
+          "enum" : [ null, "CONNECTING_IP", "XFF_HEADERS", "CONNECTING_IP XFF_HEADERS" ]
+        },
+        "objectMatchValue" : {
+          "$ref" : "#/definitions/objectMatchValueType"
+        }
+      },
+      "oneOf" : [ {
+        "required" : [ "matchType", "matchValue" ]
+      }, {
+        "required" : [ "matchType", "objectMatchValue" ]
+      } ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueRangeOrSimpleSubtype" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "enum" : [ "range", "simple" ]
+        },
+        "value" : {
+          "type" : [ "array", "null" ]
+        }
+      },
+      "required" : [ "type", "value" ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueObjectSubtype" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "object" ]
+        },
+        "nameCaseSensitive" : {
+          "type" : "boolean"
+        },
+        "nameHasWildcard" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "type" : "object",
+          "properties" : {
+            "value" : {
+              "type" : [ "array", "null" ]
+            },
+            "valueHasWildcard" : {
+              "type" : "boolean"
+            },
+            "valueCaseSensitive" : {
+              "type" : "boolean"
+            },
+            "valueEscaped" : {
+              "type" : "boolean"
+            }
+          },
+          "additionalProperties" : false
+        }
+      },
+      "required" : [ "name", "type" ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueType" : {
+      "type" : "object",
+      "oneOf" : [ {
+        "$ref" : "#/definitions/objectMatchValueRangeOrSimpleSubtype"
+      }, {
+        "$ref" : "#/definitions/objectMatchValueObjectSubtype"
+      } ]
+    }
+  },
+  "location" : "match_rule-AS-1.0.json",
+  "$ref" : "#/definitions/matchRuleType"
+}

--- a/bossman/plugins/akamai/cloudlet_v3/schemas/match_rule-ER-1.0.json
+++ b/bossman/plugins/akamai/cloudlet_v3/schemas/match_rule-ER-1.0.json
@@ -1,0 +1,177 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "EDGE REDIRECTOR MATCH RULE",
+  "description" : "applied to create/update match rule requests for ER cloudlets, where requests are of the form: POST|PUT /api/v2/policies/{policyId}/versions/{versionId}/rules/{ruleId}",
+  "version" : "1.0",
+  "type" : "object",
+  "definitions" : {
+    "matchRuleType" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : [ "string", "null" ],
+          "maxLength" : 8192
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "erMatchRule" ]
+        },
+        "start" : {
+          "type" : "integer",
+          "minimum" : 0
+        },
+        "end" : {
+          "type" : "integer",
+          "minimum" : 0
+        },
+        "id" : {
+          "type" : [ "integer", "null" ]
+        },
+        "matches" : {
+          "type" : [ "array", "null" ],
+          "items" : {
+            "$ref" : "#/definitions/matchCriteriaType"
+          }
+        },
+        "disabled" : {
+          "type" : "boolean"
+        },
+        "akaRuleId" : {
+          "type" : "string"
+        },
+        "matchURL" : {
+          "type" : [ "string", "null" ],
+          "maxLength" : 8192
+        },
+        "redirectURL" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "useIncomingQueryString" : {
+          "type" : "boolean"
+        },
+        "useIncomingSchemeAndHost" : {
+          "type" : "boolean"
+        },
+        "useRelativeUrl" : {
+          "type" : "string",
+          "enum" : [ "none", "copy_scheme_hostname", "relative_url" ]
+        },
+        "statusCode" : {
+          "type" : "integer",
+          "enum" : [ 301, 302, 303, 307, 308 ]
+        },
+        "matchesAlways" : {
+          "type" : "boolean"
+        }
+      },
+      "additionalProperties" : false,
+      "required" : [ "type", "redirectURL", "statusCode" ],
+      "not" : {
+        "required" : [ "matches", "matchesAlways" ]
+      }
+    },
+    "matchCriteriaType" : {
+      "type" : "object",
+      "properties" : {
+        "caseSensitive" : {
+          "type" : "boolean"
+        },
+        "matchValue" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "negate" : {
+          "type" : "boolean"
+        },
+        "matchOperator" : {
+          "type" : "string",
+          "enum" : [ "contains", "exists", "equals" ]
+        },
+        "matchType" : {
+          "type" : "string",
+          "enum" : [ "header", "hostname", "path", "extension", "query", "regex", "cookie", "deviceCharacteristics", "clientip", "continent", "countrycode", "regioncode", "protocol", "method", "proxy" ]
+        },
+        "checkIPs" : {
+          "type" : "string",
+          "enum" : [ null, "CONNECTING_IP", "XFF_HEADERS", "CONNECTING_IP XFF_HEADERS" ]
+        },
+        "objectMatchValue" : {
+          "$ref" : "#/definitions/objectMatchValueType"
+        }
+      },
+      "oneOf" : [ {
+        "required" : [ "matchType", "matchValue" ]
+      }, {
+        "required" : [ "matchType", "objectMatchValue" ]
+      } ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueRangeOrSimpleSubtype" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "enum" : [ "range", "simple" ]
+        },
+        "value" : {
+          "type" : [ "array", "null" ]
+        }
+      },
+      "required" : [ "type", "value" ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueObjectSubtype" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "object" ]
+        },
+        "nameCaseSensitive" : {
+          "type" : "boolean"
+        },
+        "nameHasWildcard" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "type" : "object",
+          "properties" : {
+            "value" : {
+              "type" : [ "array", "null" ]
+            },
+            "valueHasWildcard" : {
+              "type" : "boolean"
+            },
+            "valueCaseSensitive" : {
+              "type" : "boolean"
+            },
+            "valueEscaped" : {
+              "type" : "boolean"
+            }
+          },
+          "additionalProperties" : false
+        }
+      },
+      "required" : [ "name", "type" ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueType" : {
+      "type" : "object",
+      "oneOf" : [ {
+        "$ref" : "#/definitions/objectMatchValueRangeOrSimpleSubtype"
+      }, {
+        "$ref" : "#/definitions/objectMatchValueObjectSubtype"
+      } ]
+    }
+  },
+  "location" : "match_rule-ER-1.0.json",
+  "$ref" : "#/definitions/matchRuleType"
+}

--- a/bossman/plugins/akamai/cloudlet_v3/schemas/match_rule-FR-1.0.json
+++ b/bossman/plugins/akamai/cloudlet_v3/schemas/match_rule-FR-1.0.json
@@ -1,0 +1,170 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "FORWARD REWRITE MATCH RULE",
+  "description" : "applied to create/update match rule requests for FR cloudlets, where requests are of the form: POST|PUT /api/v2/policies/{policyId}/versions/{versionId}/rules/{ruleId}",
+  "version" : "1.0",
+  "type" : "object",
+  "definitions" : {
+    "matchRuleType" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : [ "string", "null" ],
+          "maxLength" : 8192
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "frMatchRule" ]
+        },
+        "start" : {
+          "type" : "integer",
+          "minimum" : 0
+        },
+        "end" : {
+          "type" : "integer",
+          "minimum" : 0
+        },
+        "id" : {
+          "type" : [ "integer", "null" ]
+        },
+        "matches" : {
+          "type" : [ "array", "null" ],
+          "items" : {
+            "$ref" : "#/definitions/matchCriteriaType"
+          }
+        },
+        "disabled" : {
+          "type" : "boolean"
+        },
+        "akaRuleId" : {
+          "type" : "string"
+        },
+        "matchURL" : {
+          "type" : [ "string", "null" ],
+          "maxLength" : 8192
+        },
+        "forwardSettings" : {
+          "type" : "object",
+          "properties" : {
+            "pathAndQS" : {
+              "type" : "string",
+              "minLength" : 1,
+              "maxLength" : 8192
+            },
+            "useIncomingQueryString" : {
+              "type" : "boolean"
+            },
+            "originId" : {
+              "type" : [ "string", "null" ],
+              "maxLength" : 8192
+            }
+          },
+          "additionalProperties" : false
+        }
+      },
+      "additionalProperties" : false,
+      "required" : [ "type", "forwardSettings" ]
+    },
+    "matchCriteriaType" : {
+      "type" : "object",
+      "properties" : {
+        "caseSensitive" : {
+          "type" : "boolean"
+        },
+        "matchValue" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "negate" : {
+          "type" : "boolean"
+        },
+        "matchOperator" : {
+          "type" : "string",
+          "enum" : [ "contains", "exists", "equals" ]
+        },
+        "matchType" : {
+          "type" : "string",
+          "enum" : [ "header", "hostname", "path", "extension", "query", "regex", "cookie", "deviceCharacteristics", "clientip", "continent", "countrycode", "regioncode", "protocol", "method", "proxy" ]
+        },
+        "checkIPs" : {
+          "type" : "string",
+          "enum" : [ null, "CONNECTING_IP", "XFF_HEADERS", "CONNECTING_IP XFF_HEADERS" ]
+        },
+        "objectMatchValue" : {
+          "$ref" : "#/definitions/objectMatchValueType"
+        }
+      },
+      "oneOf" : [ {
+        "required" : [ "matchType", "matchValue" ]
+      }, {
+        "required" : [ "matchType", "objectMatchValue" ]
+      } ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueRangeOrSimpleSubtype" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "enum" : [ "range", "simple" ]
+        },
+        "value" : {
+          "type" : [ "array", "null" ]
+        }
+      },
+      "required" : [ "type", "value" ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueObjectSubtype" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 8192
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "object" ]
+        },
+        "nameCaseSensitive" : {
+          "type" : "boolean"
+        },
+        "nameHasWildcard" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "type" : "object",
+          "properties" : {
+            "value" : {
+              "type" : [ "array", "null" ]
+            },
+            "valueHasWildcard" : {
+              "type" : "boolean"
+            },
+            "valueCaseSensitive" : {
+              "type" : "boolean"
+            },
+            "valueEscaped" : {
+              "type" : "boolean"
+            }
+          },
+          "additionalProperties" : false
+        }
+      },
+      "required" : [ "name", "type" ],
+      "additionalProperties" : false
+    },
+    "objectMatchValueType" : {
+      "type" : "object",
+      "oneOf" : [ {
+        "$ref" : "#/definitions/objectMatchValueRangeOrSimpleSubtype"
+      }, {
+        "$ref" : "#/definitions/objectMatchValueObjectSubtype"
+      } ]
+    }
+  },
+  "location" : "match_rule-FR-1.0.json",
+  "$ref" : "#/definitions/matchRuleType"
+}

--- a/bossman/plugins/akamai/cloudlet_v3/schemas/update-policy-version.json
+++ b/bossman/plugins/akamai/cloudlet_v3/schemas/update-policy-version.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "file://update-policy-version.json",
+  "title": "update-policy-version.json",
+  "type": "object",
+  "description": "Contains information about a policy version.",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A human-readable label for the version."
+    },
+    "matchRules": {
+      "$ref": "file://match-rules.json",
+      "description": "A list of Cloudlet-specific match rules for this shared policy. Currently, you can create match rules only for the Edge Redirector, Forward Rewrite, and Audience Segmentation Cloudlets. See [Match rules in Cloudlets API v2](https://developer.akamai.com/api/web_performance/cloudlets/v2.html#matchrules)."
+    }
+  },
+  "required": [
+    "description"
+  ]
+}

--- a/bossman/plugins/akamai/cloudlet_v3/test.py
+++ b/bossman/plugins/akamai/cloudlet_v3/test.py
@@ -1,0 +1,75 @@
+
+from os import getenv
+from posixpath import expanduser
+import git
+import json
+from bossman.config import ResourceTypeConfig
+from bossman.errors import BossmanError
+from rich import print
+
+config = ResourceTypeConfig({
+  "module": "bossman.plugins.akamai.cloudlet_v3",
+  "pattern": "akamai/cloudlet/{name}",
+  "options": {
+    "edgerc": getenv("AKAMAI_EDGERC", expanduser("~/.edgerc")),
+    "section": getenv("AKAMAI_EDGERC_SECTION", "default"),
+    "switch_key": getenv("AKAMAI_EDGERC_SWITCHKEY", None),
+  }
+})
+
+POLICY_NAME = 'ER_ak_hogg_fr_shared_policy'
+
+##############################################################################
+
+import git
+from bossman.plugins.akamai.cloudlet_v3.client import CloudletAPIV3Client
+
+client = CloudletAPIV3Client(config.options['edgerc'], config.options['section'], config.options.get('switch_key', None))
+policy = client.get_policy_by_name(POLICY_NAME)
+print(policy)
+
+##############################################################################
+
+policy_version = client.get_policy_version(policy.id, 1)
+print(policy_version)
+
+##############################################################################
+
+from bossman.plugins.akamai.cloudlet_v3.resourcetype import ResourceType
+
+rt = ResourceType(git.Repo(), config)
+
+res = rt.create_resource('akamai/cloudlet/' + POLICY_NAME, name=POLICY_NAME)
+print(res.name)
+print(rt.get_resource_status(res))
+
+
+##############################################################################
+
+from bossman.plugins.akamai.cloudlet_v3.schema import validate_policy_version
+
+data = json.loads(
+  """
+  {
+      "descrip22tion": "Initial version",
+      "matchRules": [
+          {
+              "end": 0,
+              "name": "Redirect images",
+              "matchURL": "/images/*",
+              "redirectURL": "/static/images/*",
+              "start": 0,
+              "statusCode": 302,
+              "type": "erMatchRule",
+              "useIncomingQueryString": true,
+              "useRelativeUrl": "relative_url"
+          }
+      ]
+  }
+  """
+)
+
+try:
+  validate_policy_version(data)
+except BossmanError as e:
+  print(e)

--- a/bossman/plugins/akamai/cloudlet_v3/ui.py
+++ b/bossman/plugins/akamai/cloudlet_v3/ui.py
@@ -1,0 +1,178 @@
+import re
+from functools import cached_property
+from typing import List
+from bossman.abc import ResourceApplyResultABC, ResourceStatusABC
+from bossman.errors import BossmanError
+from bossman.plugins.akamai.cloudlet_v3.resource import SharedPolicyResource
+from bossman.plugins.akamai.cloudlet_v3.data import Network, SharedPolicyActivationStatus, SharedPolicyVersion, SharedPolicyActivation
+from bossman.plugins.akamai.utils import GenericVersionComments
+from bossman.repo import Repo, Revision
+
+
+
+class SharedPolicyVersionStatus:
+  def __init__(self, repo: Repo, resource: SharedPolicyResource, policyVersion: SharedPolicyVersion, productionActivation: SharedPolicyActivation, stagingActivation: SharedPolicyActivation):
+    self.repo = repo
+    self.resource = resource
+    self.policyVersion = policyVersion
+    self.productionActivation = productionActivation
+    self.stagingActivation = stagingActivation
+
+  @property
+  def version(self) -> int:
+    return self.policyVersion.version
+
+  @cached_property
+  def comments(self) -> GenericVersionComments:
+    return GenericVersionComments(self.policyVersion.description)
+
+  @cached_property
+  def author(self):
+    return self.comments.author or self.policyVersion.modifiedBy
+
+  @cached_property
+  def productionStatus(self):
+    return self.productionActivation.status if self.productionActivation != None else None
+
+  @cached_property
+  def stagingStatus(self):
+    return self.stagingActivation.status if self.stagingActivation != None else None
+
+  def __rich_console__(self, *args, **kwargs):
+    parts = []
+    comments = self.comments
+
+    parts.append(r'[grey53]v{version}[/]'.format(version=self.version))
+
+    if comments.commit:
+      try:
+        revision = self.repo.get_revision(comments.commit, self.resource.paths)
+        notes = revision.get_notes(self.resource.path)
+        if notes.get("has_errors", False) == True:
+          parts.append(":boom:")
+      except BossmanError:
+        # if the commit is not found, maybe it wasn't pushed by the other party
+        pass
+
+    networks = []
+    for network in (Network.PRODUCTION, Network.STAGING):
+      networkStatus = self.productionStatus if network == Network.PRODUCTION else self.stagingStatus
+      statusIndicator = ""
+      if networkStatus == SharedPolicyActivationStatus.IN_PROGRESS:
+        statusIndicator = ":hourglass:"
+      if networkStatus in (SharedPolicyActivationStatus.SUCCESS, SharedPolicyActivationStatus.IN_PROGRESS):
+        networks.append("[bold {}]{}{}[/]".format(network.color, network.alias,  statusIndicator))
+    if len(networks):
+      parts.append(",".join(networks))
+
+    if not comments.commit:
+      parts.append(":stop_sign: [magenta]dirty[/]")
+
+    if comments.subject_line:
+      parts.append(r'[bright_white]"{subject_line}"[/]'.format(subject_line=comments.subject_line))
+
+    def branch_status(branch):
+      revs_since = self.repo.get_revisions(comments.commit, branch)
+      missing_revs_since = self.repo.get_revisions(comments.commit, branch, self.resource.paths)
+      ref = branch
+      if len(revs_since):
+        ref += "~{}".format(len(revs_since))
+      color = "dark_olive_green3"
+      if len(missing_revs_since):
+        color = "rosy_brown"
+      parts.append(r'[{}]\[{}][/]'.format(color, ref))
+
+    if comments.commit:
+      rev_branches = self.repo.get_branches_containing(comments.commit)
+      if len(rev_branches) == 0:
+        # If the comment referenced no commit, or if the commit was not found
+        # on any branch (which is possible if history was rewritten or the branch
+        # containing that commit was dropped without being merged), indicate question mark
+        parts.append(r':question:')
+      else:
+        for branch in rev_branches:
+          branch_status(branch)
+        for tag in self.repo.get_tags_pointing_at(comments.commit):
+          parts.append(r'[bright_cyan]\[{}][/]'.format(tag))
+
+    if self.author:
+      parts.append("[grey53]{}[/]".format(self.author.rsplit(" ", 1)[0]))
+
+    yield " ".join(parts)
+
+
+
+class SharedPolicyStatus(ResourceStatusABC):
+  def __init__(self, repo: Repo, resource: SharedPolicyResource, versions: List[SharedPolicyVersionStatus], exists: bool, error=None):
+    self.repo = repo
+    self.resource = resource
+    self.versions = sorted(versions, key=lambda v: int(v.version), reverse=True)
+    self._exists = exists
+    self.error = error
+
+  @property
+  def exists(self) -> bool:
+    return self._exists
+
+  @property
+  def dirty(self) -> bool:
+    if not self.exists:
+      return False
+    if len(self.versions) == 0:
+      return False
+    comments = self.versions[0].comments
+    if comments.commit:
+        return False
+    return True
+
+  def __rich_console__(self, *args, **kwargs):
+    if self.error is not None:
+      from rich.panel import Panel
+      from rich.syntax import Syntax
+      import yaml
+      error_yaml = yaml.safe_dump(self.error.args[0])
+      yield '{}\n{}'.format(type(self.error).__name__, Syntax(error_yaml, "yaml").highlight(error_yaml))
+    elif not self.exists:
+      yield "[gray31]not found[/]"
+    elif len(self.versions) == 0:
+      yield "[gray31]no policy versions[/]"
+    else:
+      for version in self.versions:
+        yield version
+
+class SharedPolicyApplyResult(ResourceApplyResultABC):
+  def __init__(self,
+              resource: SharedPolicyResource,
+              revision: Revision,
+              policy_version: SharedPolicyVersion=None,
+              error=None):
+    self.resource = resource
+    self.revision = revision
+    self.policy_version = policy_version
+    self.error = error
+
+  @property
+  def had_errors(self) -> bool:
+    return self.error != None
+
+  def __rich_console__(self, *args, **kwargs):
+    parts = []
+    parts.append(r':arrow_up:')
+    parts.append(self.resource.__rich__())
+    parts.append(r'[grey53][{h}][/]'.format(h=self.revision.id))
+    if self.policy_version:
+      parts.append(r'[grey53]v{version}[/]'.format(version=self.policy_version.version))
+    if self.revision.short_message:
+      parts.append(r'[bright_white]"{subject_line}"[/]'.format(subject_line=self.revision.short_message))
+    author = self.revision.author_name
+    if author:
+      parts.append("[grey53]{}[/]".format(author))
+    if self.had_errors:
+      parts.append(":boom:")
+    yield " ".join(parts)
+    if self.error is not None:
+      from rich.panel import Panel
+      from rich.syntax import Syntax
+      import yaml
+      error_yaml = yaml.safe_dump(self.error.args[0])
+      yield '{}\n{}'.format(type(self.error).__name__, Syntax(error_yaml, "yaml").highlight(error_yaml))

--- a/bossman/plugins/akamai/property.py
+++ b/bossman/plugins/akamai/property.py
@@ -17,6 +17,7 @@ from bossman.abc import ResourceTypeABC
 from bossman.abc import ResourceStatusABC
 from bossman.abc import ResourceABC
 from bossman.abc import ResourceApplyResultABC
+from bossman.plugins.akamai.utils import GenericVersionComments
 from bossman.repo import Repo, Revision, RevisionDetails
 from bossman.plugins.akamai.lib.papi import (
   PAPIClient,
@@ -66,56 +67,6 @@ class PropertyResource(ResourceABC):
     prefix = self.path.replace(self.name, "")
     return "[grey53]{}[/][yellow]{}[/]".format(prefix, self.name)
 
-class PropertyVersionComments:
-  @staticmethod
-  def from_revision(revision: Revision):
-    comments = StringIO()
-    comments.write(revision.message.strip())
-    comments.write("\n\n")
-    comments.write("commit: {}\n".format(revision.id))
-    comments.write("branch: {}\n".format(", ".join(revision.branches)))
-    comments.write("author: {} <{}>\n".format(revision.author_name, revision.author_email))
-    if revision.author_email != revision.committer_email:
-      comments.write("committer: {} <{}>\n".format(revision.commit.committer.name, revision.commit.committer.email))
-    return PropertyVersionComments(comments.getvalue())
-
-  def __init__(self, comments: str):
-    parts = comments.strip().rsplit("\n\n", 1)
-    self.message = parts[0]
-    self.metadata = (OrderedDict(re.findall(r"^([^:]+):\s*(.*)$", parts[1], re.MULTILINE))
-      if len(parts) == 2
-      else {})
-
-  def __str__(self) -> str:
-    return "{}\n\n{}".format(
-      self.message,
-      "\n".join(
-        "{}: {}".format(k, v)
-        for k, v in self.metadata.items()
-      )
-    )
-
-  @property
-  def commit(self):
-    return self.metadata.get("commit", None)
-
-  @property
-  def subject_line(self):
-    # 72 chars matches GitHub guidance, but it's a bit long for the console
-    return self.message.split("\n")[0][:40]
-
-  @property
-  def branch(self):
-    return self.metadata.get("branch", None)
-
-  @property
-  def author(self):
-    return self.metadata.get("author", None)
-
-  @property
-  def committer(self):
-    return self.metadata.get("committer", None)
-
 class PropertyStatus(ResourceStatusABC):
   def __init__(self, repo: Repo, resource: PropertyResource, versions: list, error=None):
     self.repo = repo
@@ -132,7 +83,7 @@ class PropertyStatus(ResourceStatusABC):
     if not self.exists:
       return False
     if self.versions[0].note is not None:
-      comments = PropertyVersionComments(self.versions[0].note)
+      comments = GenericVersionComments(self.versions[0].note)
       if comments.commit:
         return False
     return True
@@ -149,7 +100,7 @@ class PropertyStatus(ResourceStatusABC):
     else:
       for version in self.versions:
         parts = []
-        comments = PropertyVersionComments(version.note)
+        comments = GenericVersionComments(version.note)
 
         parts.append(r'[grey53]v{version}[/]'.format(version=version.propertyVersion))
 
@@ -360,7 +311,7 @@ class ResourceType(ResourceTypeABC):
       # before changing anything in PAPI, check that the json files are valid
       rules_json = self.validate_rules(resource, rules)
       # Update the rule tree with metadata from the revision commit.
-      comments = PropertyVersionComments.from_revision(revision)
+      comments = GenericVersionComments.from_revision(revision)
       rules_json.update(comments=str(comments))
 
       hostnames_json = None

--- a/bossman/plugins/akamai/utils.py
+++ b/bossman/plugins/akamai/utils.py
@@ -1,0 +1,56 @@
+
+from collections import OrderedDict
+from io import StringIO
+import re
+from bossman.repo import Revision
+
+
+class GenericVersionComments:
+  @staticmethod
+  def from_revision(revision: Revision):
+    comments = StringIO()
+    comments.write(revision.message.strip())
+    comments.write("\n\n")
+    comments.write("commit: {}\n".format(revision.id))
+    comments.write("branch: {}\n".format(", ".join(revision.branches)))
+    comments.write("author: {} <{}>\n".format(revision.author_name, revision.author_email))
+    if revision.author_email != revision.committer_email:
+      comments.write("committer: {} <{}>\n".format(revision.commit.committer.name, revision.commit.committer.email))
+    return GenericVersionComments(comments.getvalue())
+
+  def __init__(self, comments: str):
+    parts = comments.strip().rsplit("\n\n", 1)
+    self.message = parts[0]
+    self.metadata = (OrderedDict(re.findall(r"^([^:]+):\s*(.*)$", parts[1], re.MULTILINE))
+      if len(parts) == 2
+      else {})
+
+  def __str__(self) -> str:
+    return "{}\n\n{}".format(
+      self.message,
+      "\n".join(
+        "{}: {}".format(k, v)
+        for k, v in self.metadata.items()
+      )
+    )
+
+  @property
+  def commit(self):
+    return self.metadata.get("commit", None)
+
+  @property
+  def subject_line(self):
+    # 72 chars matches GitHub guidance, but it's a bit long for the console
+    return self.message.split("\n")[0][:40]
+
+  @property
+  def branch(self):
+    return self.metadata.get("branch", None)
+
+  @property
+  def author(self):
+    return self.metadata.get("author", None)
+
+  @property
+  def committer(self):
+    return self.metadata.get("committer", None)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -8,3 +8,4 @@ Plugins
    :caption: Contents:
 
    plugins/akamai/property
+   plugins/akamai/cloudlets_v3

--- a/docs/plugins/akamai/cloudlets_v3.rst
+++ b/docs/plugins/akamai/cloudlets_v3.rst
@@ -1,0 +1,86 @@
+.. _plugins_akamai_cloudlet_v3:
+
+Akamai Cloudlets (v3)
+================================
+
+This page provides reference information about how bossman commands relate to
+Akamai Cloudlets management.
+
+.. warning::
+    Only the cloudlets supported by the Akamai Cloudlets v3 API are currently supported by this
+    plugin. The complete list of supported cloudlets is on `developer.akamai.com <https://developer.akamai.com/api/web_performance/cloudlets/v3.html#cloudletsthatusethisapi>`_.
+    Please feel free to open a GitHub issue if your use case requires another Cloudlet.
+
+Resource Configuration
+________________________________
+
+.. code-block:: yaml
+
+  resources:
+    - module: bossman.plugins.akamai.cloudlet_v3
+      pattern: akamai/cloudlets/{name}
+      options:
+        edgerc: ~/.edgerc
+        section: default
+        #env_prefix: ""
+        #switch_key: xyz
+
+The above are the default values, applied even if the ``.bossman`` configuration file is
+not present. You only need to configure if you need to depart from the defaults.
+
+With these defaults, Bossman will look for folders under ``akamai/cloudlet`` and treat
+them as Akamai Property configurations. The ``{name}`` placeholder is required and defines
+the name of the property to be managed.
+
+.. warning::
+    The name may only have letters, numbers, and underscores. This is stricter than may be allowed by
+    your filesystem implementation.
+
+It is also possible to pass values from the environment. Please refer to :ref:`plugins_akamai_property`
+for more information on this topic.
+
+The next section details the structure of the resource, the files Bossman expects to find
+within the property configuration folder.
+
+Resource Structure
+________________________________
+
+An Akamai cloudlet is composed of one file, ``policy.json``, which describes both the necessary
+metadata for managing the policy, and for managing the rules that apply when the cloudlet is
+invoked.
+
+The schema of this file is custom to ``bossman`` and cannot be reused in a direct API call.
+
+.. code-block:: json
+
+  {
+    "cloudletType": "ER",
+    "description": "Main redirect rules",
+    "groupId": 200128,
+    "matchRules": [
+        {
+          "matchURL": "/images/*",
+          "name": "Redirect images",
+          "redirectURL": "/static/images4/*",
+          "statusCode": 302,
+          "type": "erMatchRule",
+          "useIncomingQueryString": true,
+          "useRelativeUrl": "relative_url"
+        }
+    ]
+  }
+
+The following top-level fields belong to `the Policy data object <https://developer.akamai.com/api/web_performance/cloudlets/v3.html#policy>`_, you will find their
+documentation there:
+
+* ``cloudletType``
+* ``description``
+* ``groupId``
+
+The ``matchRules`` top-level field defines the actual logic and is specified on the `Policy Version data object <https://developer.akamai.com/api/web_performance/cloudlets/v3.html#version>`_.
+
+Usage Notes
+________________________________
+
+Because cloudlets have a very similar lifecycle to Akamai properties, please refer to :ref:`plugins_akamai_property` for any details about
+how the different Bossman commands relate to Cloudlets.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ rich>=6
 # constrain to 3.x because of https://github.com/ynohat/bossman/issues/12
 jsonschema>=3.2.0,<4.0.0
 packaging
+cattrs>=1.8,<2.0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     "Operating System :: OS Independent",
   ],
   packages=find_namespace_packages(include=['bossman', 'bossman.*']),
+  package_data={'bossman.plugins.akamai.cloudlet_v3': ['schemas/*.json']},
   install_requires=requirements,
   python_requires='>=3.8,<4',
   zip_safe=False


### PR DESCRIPTION
Here is a PR for cloudlets v3 support.

There is some documentation in [docs/plugins/akamai/cloudlets_v3.rst](docs/plugins/akamai/cloudlets_v3.rst) and you'll find the an example in https://github.com/ynohat/bossman-demo.

There is one maybe surprising thing here: the resource is defined as a single file (policy.json) which contains something similar to this:

```
local globals = std.extVar('globals');

{
  cloudletType: 'ER',
  groupId: std.parseInt(globals.groupId),
  description: 'Main redirect rules',
  matchRules: [
    {
      type: 'erMatchRule',
      name: 'Redirect images',
      matchURL: '/images/*',
      statusCode: 302,
      redirectURL: '/static/images4/*',
      useIncomingQueryString: true,
      useRelativeUrl: 'relative_url',
    },
  ],
}
```

This is not a valid API object (it's a mix of the Policy and Version objects). I decided to do it this way because:

* Bossman requires cloudletType, groupId and description to be able to create the policy if it doesn't exist
* The matchRules field of course describes the business logic, and comes from the Version object, whose only other field is a description field whose value is constructed from the git commit

So merging the two schemas to express Bossman's minimum requirements seems like the best DX. Happy to bounce this around.