### PR TITLE
Exact match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 .vscode
 *.code-workspace
 .bossmancache
+
+#bossman
+.bossmancache.dat
+.bossmancache.dir

--- a/bossman/cli/apply_cmd.py
+++ b/bossman/cli/apply_cmd.py
@@ -15,14 +15,15 @@ console = get_console()
 
 def init(subparsers: argparse._SubParsersAction):
   parser = subparsers.add_parser("apply", help="apply local changes to remotes")
+  parser.add_argument("-e", "--exact-match", action="store_true", default=False, help="match resource exactly")
   parser.add_argument("--force", action="store_true", default=False, help="don't skip dirty resources")
   parser.add_argument("--dry-run", action="store_true", default=False, help="show what would be applied, but don't actually do anything")
   parser.add_argument("--since", default=None, help="apply only revisions since this commit ref (useful to skip early history)")
   parser.add_argument("glob", nargs="*", default="*", help="select resources by glob pattern")
   parser.set_defaults(func=exec)
 
-def exec(bossman: Bossman, glob, force:bool, dry_run:bool, since, **kwargs):
-  resources = bossman.get_resources(*glob)
+def exec(bossman: Bossman, glob, exact_match:bool, force:bool, dry_run:bool, since, **kwargs):
+  resources = bossman.get_resources(*glob, exact_match=exact_match)
   futures = []
   had_errors = False
   with ThreadPoolExecutor(10, "apply") as executor:

--- a/bossman/cli/log_cmd.py
+++ b/bossman/cli/log_cmd.py
@@ -10,12 +10,13 @@ console = Console()
 
 def init(subparsers: argparse._SubParsersAction):
   parser = subparsers.add_parser("log", help="show resource change history")
+  parser.add_argument("-e", "--exact-match", action="store_true", default=False, help="match resource exactly")
   parser.add_argument("glob", nargs="*", default="*", help="select resources by glob pattern")
   parser.set_defaults(func=exec)
 
-def exec(bossman: Bossman, glob, *args, **kwargs):
+def exec(bossman: Bossman, glob, exact_match:bool, *args, **kwargs):
   bossman.repo.fetch_notes("*")
-  resources = bossman.get_resources(*glob)
+  resources = bossman.get_resources(*glob, exact_match=exact_match)
   revisions = bossman.get_revisions(resources=resources)
   for revision in revisions:
     view = RevisionView(bossman, revision, resources)

--- a/bossman/cli/release_cmd.py
+++ b/bossman/cli/release_cmd.py
@@ -16,19 +16,21 @@ console = Console()
 
 def init(subparsers: argparse._SubParsersAction):
   prerelease_parser = subparsers.add_parser("prerelease", help="prerelease applicable resources")
+  prerelease_parser.add_argument("-e", "--exact-match", action="store_true", default=False, help="match resource exactly")
   prerelease_parser.add_argument("--yes", action="store_true", default=False, help="don't prompt")
   prerelease_parser.add_argument("--rev", required=False, default="HEAD", help="commit id or git ref to prerelease")
   prerelease_parser.add_argument("glob", nargs="*", default="*", help="select resources by glob pattern")
   prerelease_parser.set_defaults(func=exec, action="prerelease")
 
   release_parser = subparsers.add_parser("release", help="release applicable resources")
+  release_parser.add_argument("-e", "--exact-match", action="store_true", default=False, help="match resource exactly")
   release_parser.add_argument("--yes", action="store_true", default=False, help="don't prompt")
   release_parser.add_argument("--rev", required=False, default="HEAD", help="commit id or git ref to release")
   release_parser.add_argument("glob", nargs="*", default="*", help="select resources by glob pattern")
   release_parser.set_defaults(func=exec, action="release")
 
-def exec(bossman: Bossman, yes, rev, glob, action, *args, **kwargs):
-  resources = bossman.get_resources(*glob)
+def exec(bossman: Bossman, yes, rev, glob, exact_match:bool, action, *args, **kwargs):
+  resources = bossman.get_resources(*glob, exact_match=exact_match)
   revision = bossman.get_revision(rev, resources)
 
   console.print("Preparing to {}:".format(action))

--- a/bossman/cli/status_cmd.py
+++ b/bossman/cli/status_cmd.py
@@ -8,11 +8,12 @@ from bossman.abc import ResourceStatusABC
 
 def init(subparsers: argparse._SubParsersAction):
   parser = subparsers.add_parser("status", help="show resource status")
+  parser.add_argument("-e", "--exact-match", action="store_true", default=False, help="match resource exactly")
   parser.add_argument("glob", nargs="*", default="*", help="select resources by glob pattern")
   parser.set_defaults(func=exec)
 
-def exec(bossman: Bossman, glob, *args, **kwargs):
-  resources = bossman.get_resources(*glob)
+def exec(bossman: Bossman, glob, exact_match:bool, *args, **kwargs):
+  resources = bossman.get_resources(*glob, exact_match=exact_match)
   if len(resources):
     print("On branch", bossman.get_current_branch())
 

--- a/bossman/cli/validate_cmd.py
+++ b/bossman/cli/validate_cmd.py
@@ -9,11 +9,12 @@ from bossman import Bossman
 
 def init(subparsers: argparse._SubParsersAction):
   parser = subparsers.add_parser("validate", help="validates the working tree")
+  parser.add_argument("-e", "--exact-match", action="store_true", default=False, help="match resource exactly")
   parser.add_argument("glob", nargs="*", default="*", help="select resources by glob pattern")
   parser.set_defaults(func=exec)
 
-def exec(bossman: Bossman, glob, *args, **kwargs):
-  resources = bossman.get_resources_from_working_copy(*glob)
+def exec(bossman: Bossman, glob, exact_match:bool, *args, **kwargs):
+  resources = bossman.get_resources_from_working_copy(*glob, exact_match=exact_match)
   if len(resources):
     table = Table()
     table.add_column("Resource")

--- a/docs/plugins/akamai/property.rst
+++ b/docs/plugins/akamai/property.rst
@@ -85,8 +85,8 @@ validate and version freeze property versions when they are deployed.
 ``groupId`` and ``contractId`` are required so that Bossman has enough information
 to create new properties in the appropriate location.
 
-``bossman status [glob*]``
-________________________________
+``bossman status [-e|--exact-match] [glob*]``
+__________________________________________________________________________________________________
 
 The ``status`` command displays details about *interesting* property versions.
 
@@ -116,8 +116,8 @@ In the normal case, property versions are created by bossman and their status li
 
 See `Making changes in the UI`_ for more details about handling dirty versions.
 
-``bossman apply [--force] [--dry-run] [--since=commit] [glob*]``
-_____________________________________
+``bossman apply [--force] [--dry-run] [--since=commit] [-e|--exact-match] [glob*]``
+__________________________________________________________________________________________________
 
 The ``apply`` command creates a new version for every commit on the current branch.
 
@@ -155,8 +155,8 @@ The purpose is threefold.
   record this information in a legible way in the regular Author field;
 * It provides a mechanism for bossman to correlate property versions with git revisions
 
-``bossman (pre)release [--rev HEAD] [glob*]``
-_____________________________________________
+``bossman (pre)release [--rev HEAD] [-e|--exact-match] [glob*]``
+_______________________________________________________________________
 
 **prerelease** : activates the selected revision and resources to the staging network
 

--- a/tests/test_globs_default.py
+++ b/tests/test_globs_default.py
@@ -1,0 +1,27 @@
+import pytest
+from bossman.plugins.akamai.property import PropertyResource
+from bossman import get_resources
+
+
+@pytest.fixture(scope="module")
+def resources():
+    resources = list()
+    resources.append(PropertyResource("dist/akamai/cloudlets/ER_bossman_demo", name="ER_bossman_demo"))
+    resources.append(PropertyResource("dist/akamai/property/www-dev", name="www-dev"))
+    resources.append(PropertyResource("dist/akamai/property/www-integration", name="www-integration"))
+    resources.append(PropertyResource("dist/akamai/property/www-prod", name="www-prod"))
+    return resources
+
+@pytest.mark.parametrize(
+    "glob, expected_result",
+    (
+        (["*"], ["ER_bossman_demo", "www-dev", "www-integration", "www-prod"]),
+        (["www"], ["www-dev", "www-integration", "www-prod"]),
+    ),
+)
+
+def test_glob_default(resources, glob, expected_result):
+    result = get_resources(resources, glob, False)
+    assert(len(result) == len(expected_result))
+    for r in result:
+        assert(r.name in expected_result)

--- a/tests/test_globs_exact_match.py
+++ b/tests/test_globs_exact_match.py
@@ -1,0 +1,32 @@
+import pytest
+from bossman.plugins.akamai.property import PropertyResource
+from bossman import get_resources
+
+
+@pytest.fixture(scope="module")
+def resources():
+    resources = list()
+    resources.append(PropertyResource("dist/akamai/property/global.mydomain.com", name="global.mydomain.com"))
+    resources.append(PropertyResource("dist/akamai/property/testglobal.mydomain.com", name="testglobal.mydomain.com"))
+    resources.append(PropertyResource("dist/akamai/property/logistics.mydomain.com", name="logistics.mydomain.com"))
+    resources.append(PropertyResource("dist/akamai/property/logistics.mydomain.com-related-domains", name="logistics.mydomain.com-related-domains"))
+    return resources
+
+@pytest.mark.parametrize(
+    "glob, expected_result",
+    (
+        (["*"], ["global.mydomain.com", "testglobal.mydomain.com", "logistics.mydomain.com", "logistics.mydomain.com-related-domains"]),
+        (["*/logistics.mydomain.com*"], ["logistics.mydomain.com", "logistics.mydomain.com-related-domains"]),
+        (["*/logistics.mydomain.com*"], ["logistics.mydomain.com", "logistics.mydomain.com-related-domains"]),
+        (["*/logistics.mydomain.com"], ["logistics.mydomain.com"]),
+        (["dist/akamai/property/logistics.mydomain.com"], ["logistics.mydomain.com"]),
+        (["*global.mydomain.com"], ["global.mydomain.com", "testglobal.mydomain.com"]),
+        (["*/global.mydomain.com"], ["global.mydomain.com"]),
+    ),
+)
+
+def test_glob_exact_match(resources, glob, expected_result):
+    result = get_resources(resources, glob, True)
+    assert(len(result) == len(expected_result))
+    for r in result:
+        assert(r.name in expected_result)


### PR DESCRIPTION
Hello @ynohat 
here I am sending one change to be considered.

Current bossman has no option for exact matches. Some examples:

![image](https://user-images.githubusercontent.com/32241174/144995637-bf00822b-cd86-4290-b4f1-a2d8d01e76bf.png)

![image](https://user-images.githubusercontent.com/32241174/144995800-c7db2a49-7678-4b6c-b87d-fa2fcfad98f3.png)


So I propose something like colon notation for exact matches:

![image](https://user-images.githubusercontent.com/32241174/144995712-4f69363e-beea-4d8a-847b-153d424e1c69.png)

![image](https://user-images.githubusercontent.com/32241174/144995884-032cd427-7793-4717-9404-68018a0ad6bf.png)

What do you think?

CC: @wooshcz @TomasHampl